### PR TITLE
Update default values of `ltstart` and `ltstop`

### DIFF
--- a/src/chronpy/hist/bayesian_blocks.py
+++ b/src/chronpy/hist/bayesian_blocks.py
@@ -167,10 +167,8 @@ def _sanitize_input(
                 f'length of each element of `t` ({len_t}) and '
                 f'`live_time` ({len_lt}) are not the same'
             )
-        t_as_live_time = False
     else:
         live_time = t
-        t_as_live_time = True
 
     t = [np.array(i, dtype=np.float64, order='C') for i in t]
     live_time = [np.array(i, dtype=np.float64, order='C') for i in live_time]
@@ -188,12 +186,8 @@ def _sanitize_input(
         tstop = max(ti[-1] for ti in t)
 
     if ltstart is None:
-        if t_as_live_time:
-            ltstart = [tstart] * len(live_time)
-            ltstop = [tstop] * len(live_time)
-        else:
-            ltstart = [lt[0] for lt in live_time]
-            ltstop = [lt[-1] for lt in live_time]
+        ltstart = [lt[0] for lt in live_time]
+        ltstop = [lt[-1] for lt in live_time]
 
     if not isinstance(ltstart, float | Sequence):
         raise TypeError('`ltstart` must be a float or a list of float')

--- a/tests/test_bayesian_blocks.py
+++ b/tests/test_bayesian_blocks.py
@@ -55,11 +55,13 @@ def tte_data():
 
 def test_tte_data(tte_data):
     t1, t2 = tte_data
-    bb_joint = blocks_tte([t1, t2])
-    bb = blocks_tte(np.sort(np.r_[t1, t2]))
+    # Find the union of two time series' change points
+    bb_union = blocks_tte([t1, t2])
+    # Find the change points of two time series' sum
+    bb_sum = blocks_tte(np.sort(np.r_[t1, t2]))
     bins = astropy_bayesian_blocks(np.sort(np.r_[t1, t2]))
-    assert_allclose(bb.edge, bins)
-    assert len(bb_joint.edge) == len(bins)
+    assert_allclose(np.around(bb_union.edge, 1), [-9, -0.5, 0.5, 1, 7])
+    assert_allclose(bb_sum.edge, bins)
 
 
 def test_binned_data(tte_data):


### PR DESCRIPTION
## Summary by Sourcery

Simplify the determination of ltstart and ltstop by removing special-case handling when t is treated as live_time, and update tests to validate union and sum behaviors of blocks_tte.

Bug Fixes:
- Ensure default ltstart and ltstop correctly derive from live_time bounds in all cases

Enhancements:
- Remove t_as_live_time flag and simplify ltstart/ltstop default logic in input sanitization

Tests:
- Update blocks_tte tests to distinguish union vs sum cases and adjust expected edge assertions